### PR TITLE
Remove duplicate search from being stored

### DIFF
--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -66,7 +66,7 @@ var queryURLomdbapi = "https://www.omdbapi.com/?t=" + searchInput + "&apikey=" +
     var image = $("<img>").attr("src", imgURL);
     posterDiv.append(image);
 
-    persistUserSearch(searchInput);
+    persistUserSearch(title);
   }
 else {
   console.log("This is not a valid film");
@@ -171,6 +171,8 @@ function displayLocalStorageOnInitialLoad() {
         liElement.text(element);
         $("#history").append(liElement);
     });
+
+    $("#history-container").css("margin-bottom", "20px");
 }
 
 function searchHistoryButtonListener() {

--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -143,6 +143,14 @@ function persistUserSearch(input) {
     if (storedSearches === null) {
         storedSearches = [input];
     } else {
+        // remove duplicate search
+        const index = storedSearches.findIndex(function (element) {
+            return element === input;
+        })
+        if (index >= 0) {
+            storedSearches.splice(index, 1);
+        }
+
         // ensure no more then 5 searches are displayed
         storedSearches.unshift(input);
         if (storedSearches.length > MAX_STORED_SEARCHES) {

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
             </div>
         </div>
     </div>
-    <div class="container">
+    <div class="container" id="history-container">
         <ul class="list-group list-group-flush" id="history">
 
         </ul>


### PR DESCRIPTION
Closes #1 

This PR removes duplicate searches from being stored in local storage.
It also adds a bottom margin to search history and saves the correct film title in search 